### PR TITLE
changed vh to %

### DIFF
--- a/frontend/src/app/editor/utils/Code.tsx
+++ b/frontend/src/app/editor/utils/Code.tsx
@@ -73,7 +73,7 @@ export const Code = ({ selectedFile, onChange }: CodeProps) => {
   return (
     <div className="flex-1 m-0 text-base">
       <Editor
-        height="100vh"
+        height="100%"
         language={language}
         value={selectedFile.content}
         theme="no-errors"


### PR DESCRIPTION
vh is based on he view port and % is based on the parent element. so when using vh the element (the editor)  will be larger than the parent and some of the bottom text got covered up.