### PR TITLE
test: verify fs file operations

### DIFF
--- a/backend/src/services/file.test.ts
+++ b/backend/src/services/file.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import {
+  getFileTree,
+  getFileContentTree,
+  writeFile,
+  readFile,
+  renameFile,
+  removeFile,
+} from "./file";
+
+test("file operations without Docker", async () => {
+  const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), "project-"));
+
+  try {
+    await writeFile(projectPath, "dir/sample.txt", "hello");
+    const content = await readFile(projectPath, "dir/sample.txt");
+    expect(content).toBe("hello");
+
+    await renameFile(projectPath, "dir/sample.txt", "dir/renamed.txt");
+    const renamed = await readFile(projectPath, "dir/renamed.txt");
+    expect(renamed).toBe("hello");
+
+    const tree = await getFileTree(projectPath);
+    expect(tree.length).toBe(1);
+    expect(tree[0].name).toBe("dir");
+    expect(tree[0].children?.[0].name).toBe("renamed.txt");
+
+    const contentTree = await getFileContentTree(projectPath);
+    const fileItem = contentTree[0].children?.[0];
+    expect(fileItem?.content).toBe("hello");
+
+    await removeFile(projectPath, "dir/renamed.txt");
+    const treeAfter = await getFileTree(projectPath);
+    expect(treeAfter[0].children?.length).toBe(0);
+  } finally {
+    await fs.rm(projectPath, { recursive: true, force: true });
+  }
+});

--- a/backend/src/services/file.test.ts
+++ b/backend/src/services/file.test.ts
@@ -1,42 +1,48 @@
-import { expect, test } from "bun:test";
+import { expect, test, mock } from "bun:test";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
 
-import {
-  getFileTree,
-  getFileContentTree,
-  writeFile,
-  readFile,
-  renameFile,
-  removeFile,
-} from "./file";
-
 test("file operations without Docker", async () => {
   const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), "project-"));
+  const id = "test-id";
+
+  mock.module("./process", () => ({
+    getProjectPath: () => projectPath,
+  }));
+
+  const {
+    getFileTree,
+    getFileContentTree,
+    writeFile,
+    readFile,
+    renameFile,
+    removeFile,
+  } = await import("./file");
 
   try {
-    await writeFile(projectPath, "dir/sample.txt", "hello");
-    const content = await readFile(projectPath, "dir/sample.txt");
+    await writeFile(id, "dir/sample.txt", "hello");
+    const content = await readFile(id, "dir/sample.txt");
     expect(content).toBe("hello");
 
-    await renameFile(projectPath, "dir/sample.txt", "dir/renamed.txt");
-    const renamed = await readFile(projectPath, "dir/renamed.txt");
+    await renameFile(id, "dir/sample.txt", "dir/renamed.txt");
+    const renamed = await readFile(id, "dir/renamed.txt");
     expect(renamed).toBe("hello");
 
-    const tree = await getFileTree(projectPath);
+    const tree = await getFileTree(id);
     expect(tree.length).toBe(1);
     expect(tree[0].name).toBe("dir");
     expect(tree[0].children?.[0].name).toBe("renamed.txt");
 
-    const contentTree = await getFileContentTree(projectPath);
+    const contentTree = await getFileContentTree(id);
     const fileItem = contentTree[0].children?.[0];
     expect(fileItem?.content).toBe("hello");
 
-    await removeFile(projectPath, "dir/renamed.txt");
-    const treeAfter = await getFileTree(projectPath);
+    await removeFile(id, "dir/renamed.txt");
+    const treeAfter = await getFileTree(id);
     expect(treeAfter[0].children?.length).toBe(0);
   } finally {
+    mock.restore();
     await fs.rm(projectPath, { recursive: true, force: true });
   }
 });

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -1,15 +1,5 @@
-import { exec } from "child_process";
-import Docker from "dockerode";
 import fs from "fs/promises";
-import { promisify } from "util";
-import { v4 as uuidv4 } from "uuid";
-
-const execAsync = promisify(exec);
-const BASE_PATH = "/app/my-nextjs-app";
-
-function getAbsolutePath(filePath: string): string {
-  return filePath.startsWith("/") ? filePath : `${BASE_PATH}/${filePath}`;
-}
+import path from "path";
 
 export interface FileItem {
   name: string;
@@ -27,417 +17,114 @@ export interface FileContentItem {
   children?: FileContentItem[];
 }
 
-export async function getFileTree(
-  docker: Docker,
-  containerId: string,
-  containerPath: string = BASE_PATH
-): Promise<FileItem[]> {
-  const container = docker.getContainer(containerId);
-
-  const findCommand = [
-    "sh",
-    "-c",
-    `find ${containerPath} \\( -name node_modules -o -name .next \\) -prune -o -type f -o -type d | grep -v -E "(node_modules|\\.next)" | sort`,
-  ];
-
-  const exec = await container.exec({
-    Cmd: findCommand,
-    AttachStdout: true,
-    AttachStderr: true,
-  });
-
-  const stream = await exec.start({ Detach: false, Tty: false });
-  const output = await new Promise<string>((resolve, reject) => {
-    let data = "";
-    stream.on("data", (chunk: Buffer) => {
-      data += chunk.toString();
-    });
-    stream.on("end", () => resolve(data));
-    stream.on("error", reject);
-  });
-
-  const paths = output
-    .trim()
-    .split("\n")
-    .filter((p) => p && p !== containerPath);
-  const fileTree: Map<string, FileItem> = new Map();
-
-  fileTree.set(containerPath, {
-    name: "root",
-    path: containerPath,
-    type: "directory",
-    children: [],
-  });
-
-  for (const filePath of paths) {
-    const stat = await getFileStat(container, filePath);
-    const relativePath = filePath.replace(containerPath + "/", "");
-    const parts = relativePath.split("/");
-    const fileName = parts[parts.length - 1] || "";
-
-    const fileItem: FileItem = {
-      name: fileName,
-      path: filePath,
-      type: stat.isDirectory ? "directory" : "file",
-    };
-
-    if (stat.isDirectory) {
-      fileItem.children = [];
-    }
-
-    fileTree.set(filePath, fileItem);
-
-    const parentPath = filePath.substring(0, filePath.lastIndexOf("/"));
-    const parent = fileTree.get(parentPath || containerPath);
-    if (parent && parent.children) {
-      parent.children.push(fileItem);
-    }
-  }
-
-  const root = fileTree.get(containerPath);
-  return root?.children || [];
+function resolvePath(projectPath: string, filePath: string): string {
+  return path.isAbsolute(filePath)
+    ? filePath
+    : path.join(projectPath, filePath);
 }
 
-export async function getFileContentTree(
-  docker: Docker,
-  containerId: string,
-  containerPath: string = BASE_PATH
-): Promise<FileContentItem[]> {
-  const container = docker.getContainer(containerId);
+async function walk(
+  dir: string,
+  includeContent: boolean
+): Promise<(FileItem | FileContentItem)[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results: (FileItem | FileContentItem)[] = [];
 
-  const findCommand = [
-    "sh",
-    "-c",
-    `find ${containerPath} \\( -name node_modules -o -name .next -o -path "*/components/ui" \\) -prune -o -type f -o -type d | grep -v -E "(node_modules|\\.next|components/ui|bun\\.lock|components\\.json|next-env\\.d\\.ts|package-lock\\.json|postcss\\.config\\.mjs|favicon\\.ico|\\.gitignore)" | sort`,
-  ];
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".next") continue;
+    const fullPath = path.join(dir, entry.name);
 
-  const exec = await container.exec({
-    Cmd: findCommand,
-    AttachStdout: true,
-    AttachStderr: true,
-  });
-
-  const stream = await exec.start({ Detach: false, Tty: false });
-  const output = await new Promise<string>((resolve, reject) => {
-    let data = "";
-    stream.on("data", (chunk: Buffer) => {
-      data += chunk.toString();
-    });
-    stream.on("end", () => resolve(data));
-    stream.on("error", reject);
-  });
-
-  const paths = output
-    .trim()
-    .split("\n")
-    .filter((p) => p && p !== containerPath);
-
-  const fileTree: Map<string, FileContentItem> = new Map();
-
-  fileTree.set(containerPath, {
-    name: "root",
-    path: containerPath,
-    type: "directory",
-    children: [],
-  });
-
-  const filesToRead: string[] = [];
-  const pathToItemMap: Map<string, FileContentItem> = new Map();
-
-  for (const filePath of paths) {
-    const stat = await getFileStat(container, filePath);
-    const relativePath = filePath.replace(containerPath + "/", "");
-    const parts = relativePath.split("/");
-    const fileName = parts[parts.length - 1] || "";
-
-    const fileItem: FileContentItem = {
-      name: fileName,
-      path: filePath,
-      type: stat.isDirectory ? "directory" : "file",
-    };
-
-    if (stat.isDirectory) {
-      fileItem.children = [];
+    if (entry.isDirectory()) {
+      const children = await walk(fullPath, includeContent);
+      results.push({
+        name: entry.name,
+        path: fullPath,
+        type: "directory",
+        children,
+      });
     } else {
-      filesToRead.push(filePath);
-    }
-
-    pathToItemMap.set(filePath, fileItem);
-    fileTree.set(filePath, fileItem);
-  }
-
-  const fileContents = await readFilesBatch(docker, containerId, filesToRead);
-
-  for (const [filePath, content] of fileContents) {
-    const fileItem = pathToItemMap.get(filePath);
-    if (fileItem) {
-      fileItem.content = content;
-    }
-  }
-
-  for (const fileItem of pathToItemMap.values()) {
-    const parentPath = fileItem.path.substring(
-      0,
-      fileItem.path.lastIndexOf("/")
-    );
-    const parent = fileTree.get(parentPath || containerPath);
-    if (parent && parent.children) {
-      parent.children.push(fileItem);
-    }
-  }
-
-  const root = fileTree.get(containerPath);
-  return root?.children || [];
-}
-
-async function readFilesBatch(
-  docker: Docker,
-  containerId: string,
-  filePaths: string[]
-): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
-  const batchSize = 50;
-
-  for (let i = 0; i < filePaths.length; i += batchSize) {
-    const batch = filePaths.slice(i, i + batchSize);
-    const batchPromises = batch.map(async (filePath) => {
-      try {
-        const content = await readFile(docker, containerId, filePath);
-        return [filePath, content] as [string, string];
-      } catch (error) {
-        return [
-          filePath,
-          `Error reading file: ${
-            error instanceof Error ? error.message : "Unknown error"
-          }`,
-        ] as [string, string];
+      const item: any = {
+        name: entry.name,
+        path: fullPath,
+        type: "file",
+      };
+      if (includeContent) {
+        item.content = await fs.readFile(fullPath, "utf8");
       }
-    });
-
-    const batchResults = await Promise.all(batchPromises);
-    for (const [filePath, content] of batchResults) {
-      results.set(filePath, content);
+      results.push(item);
     }
   }
 
   return results;
 }
 
-async function getFileStat(
-  container: Docker.Container,
-  filePath: string
-): Promise<{ isDirectory: boolean }> {
-  const exec = await container.exec({
-    Cmd: ["stat", "-c", "%F", filePath],
-    AttachStdout: true,
-    AttachStderr: true,
-  });
+export async function getFileTree(projectPath: string): Promise<FileItem[]> {
+  return (await walk(projectPath, false)) as FileItem[];
+}
 
-  const stream = await exec.start({ Detach: false, Tty: false });
-  const output = await new Promise<string>((resolve, reject) => {
-    let data = "";
-    stream.on("data", (chunk: Buffer) => {
-      data += chunk.toString();
-    });
-    stream.on("end", () => resolve(data));
-    stream.on("error", reject);
-  });
-
-  return {
-    isDirectory: output.trim().includes("directory"),
-  };
+export async function getFileContentTree(
+  projectPath: string
+): Promise<FileContentItem[]> {
+  return (await walk(projectPath, true)) as FileContentItem[];
 }
 
 export async function readFile(
-  docker: Docker,
-  containerId: string,
+  projectPath: string,
   filePath: string
 ): Promise<string> {
-  const container = docker.getContainer(containerId);
-
-  const exec = await container.exec({
-    Cmd: ["sh", "-c", `cat "${filePath}" | head -c 10000000`],
-    AttachStdout: true,
-    AttachStderr: true,
-  });
-
-  const stream = await exec.start({ Detach: false, Tty: false });
-
-  return new Promise<string>((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let stderr = "";
-
-    stream.on("data", (chunk: Buffer) => {
-      if (chunk.length > 8) {
-        const header = chunk.slice(0, 8);
-        const streamType = header[0];
-
-        if (streamType === 1) {
-          chunks.push(chunk.slice(8));
-        } else if (streamType === 2) {
-          stderr += chunk.slice(8).toString("utf8");
-        }
-      } else {
-        chunks.push(chunk);
-      }
-    });
-
-    stream.on("end", () => {
-      if (stderr && stderr.trim() !== "exec /bin/sh: invalid argument") {
-        console.error("File read stderr:", stderr);
-      }
-
-      const buffer = Buffer.concat(chunks);
-      const content = buffer.toString("utf8");
-
-      const cleanContent = content.replace(/^\uFEFF/, "");
-      resolve(cleanContent);
-    });
-
-    stream.on("error", (error) => {
-      console.error("Stream error:", error);
-      reject(error);
-    });
-  });
+  const absolute = resolvePath(projectPath, filePath);
+  const content = await fs.readFile(absolute, "utf8");
+  return content.replace(/^\uFEFF/, "");
 }
 
 export async function listFiles(
-  docker: Docker,
-  containerId: string,
-  containerPath: string = BASE_PATH
+  projectPath: string,
+  dirPath: string = projectPath
 ): Promise<any[]> {
-  const container = docker.getContainer(containerId);
-  const exec = await container.exec({
-    Cmd: ["ls", "-la", containerPath],
-    AttachStdout: true,
-    AttachStderr: true,
-  });
+  const absolute = resolvePath(projectPath, dirPath);
+  const entries = await fs.readdir(absolute, { withFileTypes: true });
+  const results = [];
 
-  const stream = await exec.start({ Detach: false, Tty: false });
-  const output = await new Promise<string>((resolve, reject) => {
-    let data = "";
-    stream.on("data", (chunk: Buffer) => {
-      data += chunk.toString();
+  for (const entry of entries) {
+    const fullPath = path.join(absolute, entry.name);
+    const stat = await fs.stat(fullPath);
+    results.push({
+      name: entry.name,
+      type: entry.isDirectory() ? "directory" : "file",
+      permissions: (stat.mode & 0o777).toString(8),
+      size: stat.size.toString(),
+      modified: stat.mtime.toISOString(),
     });
-    stream.on("end", () => resolve(data));
-    stream.on("error", reject);
-  });
+  }
 
-  const lines = output.trim().split("\n");
-  return lines
-    .slice(1)
-    .map((line) => {
-      const parts = line.trim().split(/\s+/);
-      const permissions = parts[0];
-      const isDirectory = permissions!.startsWith("d");
-      const name = parts.slice(8).join(" ");
-
-      return {
-        name,
-        type: isDirectory ? "directory" : "file",
-        permissions,
-        size: parts[4],
-        modified: `${parts[5]} ${parts[6]} ${parts[7]}`,
-      };
-    })
-    .filter((item) => item.name !== "." && item.name !== "..");
+  return results;
 }
 
 export async function writeFile(
-  containerId: string,
+  projectPath: string,
   filePath: string,
   content: string
 ): Promise<void> {
-  console.log(`Writing file: ${filePath} (${content.length} characters)`);
-
-  const tempFile = `/tmp/file-${uuidv4()}`;
-
-  try {
-    await fs.writeFile(tempFile, content, "utf8");
-    console.log(`Temporary file created: ${tempFile}`);
-
-    const absolutePath = getAbsolutePath(filePath);
-    console.log(`Target path: ${absolutePath}`);
-
-    try {
-      const copyCommand = `docker cp "${tempFile}" "${containerId}:${absolutePath}"`;
-      console.log(`Executing: ${copyCommand}`);
-      const { stdout, stderr } = await execAsync(copyCommand);
-
-      if (stderr) {
-        console.log(`Copy stderr: ${stderr}`);
-      }
-      if (stdout) {
-        console.log(`Copy stdout: ${stdout}`);
-      }
-
-      console.log("File copied successfully");
-    } catch (copyError) {
-      console.log("Copy failed, trying to create directory first:", copyError);
-
-      const dirPath = absolutePath.substring(0, absolutePath.lastIndexOf("/"));
-      const createDirCommand = `docker exec "${containerId}" mkdir -p "${dirPath}"`;
-      console.log(`Executing: ${createDirCommand}`);
-
-      await execAsync(createDirCommand);
-      console.log("Directory created");
-
-      const retryCommand = `docker cp "${tempFile}" "${containerId}:${absolutePath}"`;
-      console.log(`Retrying: ${retryCommand}`);
-
-      const { stdout, stderr } = await execAsync(retryCommand);
-      if (stderr) {
-        console.log(`Retry stderr: ${stderr}`);
-      }
-      if (stdout) {
-        console.log(`Retry stdout: ${stdout}`);
-      }
-
-      console.log("File copied successfully on retry");
-    }
-
-    try {
-      const verifyCommand = `docker exec "${containerId}" head -n 5 "${absolutePath}"`;
-      const { stdout: verifyOutput } = await execAsync(verifyCommand);
-      console.log(`File verification (first 5 lines):\n${verifyOutput}`);
-    } catch (verifyError) {
-      console.log("Could not verify file content:", verifyError);
-    }
-
-    await fs.unlink(tempFile);
-    console.log("Temporary file cleaned up");
-  } catch (error) {
-    console.error("Write file error:", error);
-    try {
-      await fs.unlink(tempFile);
-    } catch (unlinkError) {
-      console.error("Failed to clean up temp file:", unlinkError);
-    }
-    throw error;
-  }
+  const absolute = resolvePath(projectPath, filePath);
+  await fs.mkdir(path.dirname(absolute), { recursive: true });
+  await fs.writeFile(absolute, content, "utf8");
 }
 
 export async function renameFile(
-  containerId: string,
+  projectPath: string,
   oldPath: string,
   newPath: string
 ): Promise<void> {
-  const absoluteOldPath = getAbsolutePath(oldPath);
-  const absoluteNewPath = getAbsolutePath(newPath);
-
-  const newDir = absoluteNewPath.substring(0, absoluteNewPath.lastIndexOf("/"));
-  const createDirCommand = `docker exec "${containerId}" mkdir -p "${newDir}"`;
-  await execAsync(createDirCommand);
-
-  const moveCommand = `docker exec "${containerId}" mv "${absoluteOldPath}" "${absoluteNewPath}"`;
-  await execAsync(moveCommand);
+  const absOld = resolvePath(projectPath, oldPath);
+  const absNew = resolvePath(projectPath, newPath);
+  await fs.mkdir(path.dirname(absNew), { recursive: true });
+  await fs.rename(absOld, absNew);
 }
 
 export async function removeFile(
-  containerId: string,
+  projectPath: string,
   filePath: string
 ): Promise<void> {
-  const absolutePath = getAbsolutePath(filePath);
-  const removeCommand = `docker exec "${containerId}" rm -rf "${absolutePath}"`;
-  await execAsync(removeCommand);
+  const absolute = resolvePath(projectPath, filePath);
+  await fs.rm(absolute, { recursive: true, force: true });
 }

--- a/backend/src/services/package.ts
+++ b/backend/src/services/package.ts
@@ -1,20 +1,30 @@
 import { exec } from "child_process";
 import { promisify } from "util";
+import * as processService from "./process";
 
 const execAsync = promisify(exec);
 
+function getCwd(id: string): string {
+  const cwd = processService.getProjectPath(id);
+  if (!cwd) throw new Error("Prozess nicht gefunden");
+  return cwd;
+}
+
 export async function addDependency(
-  projectPath: string,
+  id: string,
   packageName: string,
   isDev: boolean = false
 ): Promise<string> {
+  const cwd = getCwd(id);
   const devFlag = isDev ? "--save-dev" : "";
-  const addCommand = `pnpm add ${packageName} ${devFlag}`.trim();
-  const { stdout, stderr } = await execAsync(addCommand, { cwd: projectPath });
+  const cmd = `pnpm add ${packageName} ${devFlag}`.trim();
+  const { stdout, stderr } = await execAsync(cmd, { cwd });
   return stdout || stderr;
 }
 
-export async function buildProject(projectPath: string): Promise<string> {
-  const { stdout, stderr } = await execAsync("pnpm build", { cwd: projectPath });
+export async function buildProject(id: string): Promise<string> {
+  const cwd = getCwd(id);
+  const { stdout, stderr } = await execAsync("pnpm build", { cwd });
   return stdout || stderr;
 }
+

--- a/backend/src/services/package.ts
+++ b/backend/src/services/package.ts
@@ -2,17 +2,19 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
-const BASE_PATH = "/app/my-nextjs-app";
 
 export async function addDependency(
-  containerId: string,
+  projectPath: string,
   packageName: string,
   isDev: boolean = false
 ): Promise<string> {
-  const devFlag = isDev ? "--dev" : "";
-  const addCommand =
-    `docker exec -w ${BASE_PATH} ${containerId} bun add ${packageName} ${devFlag}`.trim();
+  const devFlag = isDev ? "--save-dev" : "";
+  const addCommand = `pnpm add ${packageName} ${devFlag}`.trim();
+  const { stdout, stderr } = await execAsync(addCommand, { cwd: projectPath });
+  return stdout || stderr;
+}
 
-  const { stdout, stderr } = await execAsync(addCommand);
+export async function buildProject(projectPath: string): Promise<string> {
+  const { stdout, stderr } = await execAsync("pnpm build", { cwd: projectPath });
   return stdout || stderr;
 }

--- a/backend/src/services/process.ts
+++ b/backend/src/services/process.ts
@@ -1,0 +1,132 @@
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs/promises";
+import path from "path";
+import getPort from "get-port";
+
+interface ProcessInfo {
+  id: string;
+  cwd: string;
+  port: number;
+  proc?: ChildProcess;
+  status: "running" | "stopped";
+  createdAt: string;
+}
+
+const processes = new Map<string, ProcessInfo>();
+const BASE_DIR = path.join("/tmp", "process-apps");
+
+async function runCommand(cmd: string, args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: "inherit" });
+    child.on("exit", (code) => {
+      code === 0 ? resolve() : reject(new Error(`${cmd} exited with code ${code}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+export async function createProcess(id: string): Promise<{ port: number }> {
+  const cwd = path.join(BASE_DIR, id);
+  await fs.mkdir(cwd, { recursive: true });
+
+  // Clone template project
+  await runCommand("git", [
+    "clone",
+    "https://github.com/ntegrals/december-nextjs-template.git",
+    cwd,
+  ], process.cwd());
+
+  // Install dependencies
+  await runCommand("pnpm", ["install"], cwd);
+
+  const port = await getPort();
+  const proc = spawn("pnpm", ["dev"], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: "inherit",
+  });
+
+  processes.set(id, {
+    id,
+    cwd,
+    port,
+    proc,
+    status: "running",
+    createdAt: new Date().toISOString(),
+  });
+
+  proc.on("exit", () => {
+    const info = processes.get(id);
+    if (info) {
+      info.status = "stopped";
+      info.proc = undefined;
+    }
+  });
+
+  return { port };
+}
+
+export async function startProcess(id: string): Promise<{ port: number }> {
+  const info = processes.get(id);
+  if (!info) throw new Error("Prozess nicht gefunden");
+  if (info.status === "running" && info.proc) return { port: info.port };
+
+  const port = await getPort();
+  const proc = spawn("pnpm", ["dev"], {
+    cwd: info.cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: "inherit",
+  });
+
+  info.port = port;
+  info.proc = proc;
+  info.status = "running";
+
+  proc.on("exit", () => {
+    info.status = "stopped";
+    info.proc = undefined;
+  });
+
+  return { port };
+}
+
+export async function stopProcess(id: string): Promise<void> {
+  const info = processes.get(id);
+  if (!info || !info.proc) throw new Error("Prozess nicht gefunden");
+  info.proc.kill();
+  info.status = "stopped";
+  info.proc = undefined;
+}
+
+export async function deleteProcess(id: string): Promise<void> {
+  const info = processes.get(id);
+  if (!info) throw new Error("Prozess nicht gefunden");
+  if (info.proc) {
+    info.proc.kill();
+  }
+  await fs.rm(info.cwd, { recursive: true, force: true });
+  processes.delete(id);
+}
+
+export function getProcessInfo(id: string): ProcessInfo | undefined {
+  return processes.get(id);
+}
+
+export function getProjectPath(id: string): string | undefined {
+  return processes.get(id)?.cwd;
+}
+
+export async function listProjectProcesses(): Promise<any[]> {
+  const list: any[] = [];
+  for (const info of processes.values()) {
+    list.push({
+      id: info.id,
+      status: info.status,
+      port: info.port,
+      url: `http://localhost:${info.port}`,
+      pid: info.proc?.pid,
+      createdAt: info.createdAt,
+    });
+  }
+  return list;
+}


### PR DESCRIPTION
This pull request refactors the project export and package management logic to remove Docker dependencies and operate directly on the filesystem, simplifying the workflow and improving compatibility. Additionally, a new test suite is added to verify file operations outside of Docker.

**Refactoring: Remove Docker Dependency and Use Filesystem**

* The `exportContainerCode` function in `export.ts` is replaced with `exportProjectCode`, which exports a project by copying files directly from the filesystem and running `pnpm build`, rather than using Docker commands.
* The `addDependency` function in `package.ts` now installs packages using `pnpm add` directly in the project directory, instead of executing commands inside a Docker container. Also, the dev flag is updated to `--save-dev`.
* A new `buildProject` function is added to `package.ts` to build the project using `pnpm build` in the specified directory, further removing Docker dependency.

**Testing: File Operations Without Docker**

* A new test suite is added in `file.test.ts` to verify file operations such as creating, reading, renaming, removing files, and building file trees, all performed directly on the filesystem without Docker.